### PR TITLE
Release 0.2.0 prep

### DIFF
--- a/extension/build-and-import-bergamot-translator.sh
+++ b/extension/build-and-import-bergamot-translator.sh
@@ -1,6 +1,7 @@
 set -e
 set -x
 
+git submodule update --init --recursive
 cd ../bergamot-translator/docker
 make
 cd ../build-wasm-docker

--- a/extension/docs/DEV.md
+++ b/extension/docs/DEV.md
@@ -45,7 +45,7 @@ cp .env.example .env.production
 git submodule update --init --recursive
 ```
 
-2. Put the model files to be included in the build into `../bergamot-translator/models/` according to the instructions [here](../bergamot-translator/README.md).
+2. Add the model files to be included in the build according to the instructions [here](../bergamot-translator/README.md).
 
 3. Run the build and import script (in the `extension/` folder in this repo):
 
@@ -55,7 +55,7 @@ git submodule update --init --recursive
 
 Repeat this process any time there has been an update in the bergamot-translator submodule.
 
-Note that changing the files in the `../bergamot-translator/models/` folder doesn't automatically invalidate the build, so better remove `../bergamot-translator/build-wasm-docker/` in those cases in order to trigger a full rebuild.
+Note that changing the files to be included in the build doesn't automatically lead to repackaged files on next build unless `../bergamot-translator/build-wasm-docker/wasm/` is removed first.
 
 ## Creating extension builds for distribution
 

--- a/extension/docs/DEV.md
+++ b/extension/docs/DEV.md
@@ -36,16 +36,19 @@ cp .env.example .env.development
 cp .env.example .env.production
 ```
 
-Build Bergamot Translator for WASM:
+## Building Bergamot Translator for WASM
+
+First, put the model files to be included in the build into `../bergamot-translator/models/` according to the instructions [../bergamot-translator/README.md](here). Then, run the build and import script (in the `extension/` folder in this repo):
 
 ```bash
-source /path/to/emsdk_env.sh
 ./build-and-import-bergamot-translator.sh
 ```
 
-Repeat this last step any time there has been an update in the bergamot-translator submodule.
+Repeat this process any time there has been an update in the bergamot-translator submodule.
 
-## Creating build artifacts
+Note that changing the files in the `../bergamot-translator/models/` folder doesn't automatically invalidate the build, so better remove `../bergamot-translator/build-wasm-docker/` in those cases in order to trigger a full rebuild.
+
+## Creating extension builds for distribution
 
 To build for Firefox:
 

--- a/extension/docs/DEV.md
+++ b/extension/docs/DEV.md
@@ -5,7 +5,8 @@
 
 - [Developing this extension](#developing-this-extension)
   - [First time setup](#first-time-setup)
-  - [Creating build artifacts](#creating-build-artifacts)
+  - [Building Bergamot Translator WASM resources and importing them to the extension](#building-bergamot-translator-wasm-resources-and-importing-them-to-the-extension)
+  - [Creating extension builds for distribution](#creating-extension-builds-for-distribution)
   - [Development mode](#development-mode)
     - [Firefox](#firefox)
     - [Chrome](#chrome)
@@ -36,9 +37,17 @@ cp .env.example .env.development
 cp .env.example .env.production
 ```
 
-## Building Bergamot Translator for WASM
+## Building Bergamot Translator WASM resources and importing them to the extension
 
-First, put the model files to be included in the build into `../bergamot-translator/models/` according to the instructions [../bergamot-translator/README.md](here). Then, run the build and import script (in the `extension/` folder in this repo):
+1. Make sure all submodules are initiated:
+
+```bash
+git submodule update --init --recursive
+```
+
+2. Put the model files to be included in the build into `../bergamot-translator/models/` according to the instructions [here](../bergamot-translator/README.md).
+
+3. Run the build and import script (in the `extension/` folder in this repo):
 
 ```bash
 ./build-and-import-bergamot-translator.sh

--- a/extension/docs/INSTALL.md
+++ b/extension/docs/INSTALL.md
@@ -14,6 +14,8 @@
 
 This document outlines how to get the v0.2.0 pre-release version of the extension running locally.
 
+Before installing, please take a minute to read [the release notes](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/tag/untagged-41617d38f820c50109b8).
+
 There are three flavors:
 
 - **Firefox - Extension UI** - Firefox version of the extension

--- a/extension/docs/INSTALL.md
+++ b/extension/docs/INSTALL.md
@@ -12,7 +12,7 @@
 
 # Installation instructions
 
-This document outlines how to get a pre-released version of the extension running locally.
+This document outlines how to get the v0.2.0 pre-release version of the extension running locally.
 
 There are three flavors:
 
@@ -30,14 +30,14 @@ There are three flavors:
 - Make sure that the following preferences are set to `false` in `about:config`:
   - `browser.translation.ui.show`
   - `browser.translation.ui.detectLanguage`
-- Click [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/v0.2.0/bergamot-browser-extension_browser.mt-0.2.0-firefox.xpi) to start the download and installation of the extension
+- Click [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/untagged-41617d38f820c50109b8/bergamot-browser-extension_browser.mt-0.2.0-firefox.xpi) to start the download and installation of the extension
 - Allow extensions to be downloaded from GitHub in the popup that comes up (Click `Continue to Installation`)
 - Add the extension to Firefox (Click `Add`)
 
 ## Chrome - Extension UI
 
 - If you haven't already, download and install [Chrome Canary](https://www.google.com/chrome/canary/) since the current release requires bleeding edge browser capabilities.
-- Download the latest Chrome zip file, linked [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/v0.2.0/bergamot-browser-extension_browser.mt-0.2.0-chrome.zip)
+- Download the latest Chrome zip file, linked [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/untagged-41617d38f820c50109b8/bergamot-browser-extension_browser.mt-0.2.0-chrome.zip)
 - Unpack the zip file locally
 - Start Chrome Canary with the following extra argument: `--js-flags="--experimental-wasm-simd"`, eg `/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary --js-flags="--experimental-wasm-simd"`
 - Enter `chrome://extensions` in Chrome's address bar and press enter
@@ -58,6 +58,6 @@ There are three flavors:
 - Make sure that the following preferences are set to `false` in `about:config`:
   - `browser.translation.ui.show`
   - `browser.translation.ui.detectLanguage`
-- Click [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/v0.2.0/translation_mozilla.org-0.2.0-firefox.xpi) to start the download and installation of the extension
+- Click [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/untagged-41617d38f820c50109b8/translation_mozilla.org-0.2.0-firefox.xpi) to start the download and installation of the extension
 - Allow extensions to be downloaded from GitHub in the popup that comes up (Click `Continue to Installation`)
 - Add the extension to Firefox (Click `Add`)

--- a/extension/docs/INSTALL.md
+++ b/extension/docs/INSTALL.md
@@ -14,7 +14,7 @@
 
 This document outlines how to get the v0.2.0 pre-release version of the extension running locally.
 
-Before installing, please take a minute to read [the release notes](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/tag/untagged-41617d38f820c50109b8).
+Before installing, please take a minute to read [the release notes](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/tag/v0.2.0).
 
 There are three flavors:
 
@@ -33,14 +33,14 @@ There are three flavors:
   - `xpinstall.signatures.required`
   - `browser.translation.ui.show`
   - `browser.translation.ui.detectLanguage`
-- Click [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/untagged-41617d38f820c50109b8/bergamot-browser-extension_browser.mt-0.2.0-firefox.xpi) to start the download and installation of the extension
+- Click [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/v0.2.0/bergamot-browser-extension_browser.mt-0.2.0-firefox.xpi) to start the download and installation of the extension
 - Allow extensions to be downloaded from GitHub in the popup that comes up (Click `Continue to Installation`)
 - Add the extension to Firefox (Click `Add`)
 
 ## Chrome - Extension UI
 
 - If you haven't already, download and install [Chrome Canary](https://www.google.com/chrome/canary/) since the current release requires bleeding edge browser capabilities.
-- Download the latest Chrome zip file, linked [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/untagged-41617d38f820c50109b8/bergamot-browser-extension_browser.mt-0.2.0-chrome.zip)
+- Download the latest Chrome zip file, linked [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/v0.2.0/bergamot-browser-extension_browser.mt-0.2.0-chrome.zip)
 - Unpack the zip file locally
 - Start Chrome Canary with the following extra argument: `--js-flags="--experimental-wasm-simd"`, eg `/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary --js-flags="--experimental-wasm-simd"`
 - Enter `chrome://extensions` in Chrome's address bar and press enter
@@ -62,6 +62,6 @@ There are three flavors:
   - `xpinstall.signatures.required`
   - `browser.translation.ui.show`
   - `browser.translation.ui.detectLanguage`
-- Click [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/untagged-41617d38f820c50109b8/translation_mozilla.org-0.2.0-firefox.xpi) to start the download and installation of the extension
+- Click [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/v0.2.0/translation_mozilla.org-0.2.0-firefox.xpi) to start the download and installation of the extension
 - Allow extensions to be downloaded from GitHub in the popup that comes up (Click `Continue to Installation`)
 - Add the extension to Firefox (Click `Add`)

--- a/extension/docs/INSTALL.md
+++ b/extension/docs/INSTALL.md
@@ -28,6 +28,7 @@ There are three flavors:
   - `javascript.options.wasm_simd`
   - `javascript.options.wasm_simd_wormhole`
 - Make sure that the following preferences are set to `false` in `about:config`:
+  - `xpinstall.signatures.required`
   - `browser.translation.ui.show`
   - `browser.translation.ui.detectLanguage`
 - Click [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/untagged-41617d38f820c50109b8/bergamot-browser-extension_browser.mt-0.2.0-firefox.xpi) to start the download and installation of the extension
@@ -56,6 +57,7 @@ There are three flavors:
   - `javascript.options.wasm_simd`
   - `javascript.options.wasm_simd_wormhole`
 - Make sure that the following preferences are set to `false` in `about:config`:
+  - `xpinstall.signatures.required`
   - `browser.translation.ui.show`
   - `browser.translation.ui.detectLanguage`
 - Click [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/untagged-41617d38f820c50109b8/translation_mozilla.org-0.2.0-firefox.xpi) to start the download and installation of the extension

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bergamot-browser-extension",
   "description": "bergamot-browser-extension",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Mozilla",
   "dependencies": {
     "@ant-design/colors": "^4.0.5",

--- a/extension/src/experiment-apis/translateUi/content/translation-notification.js
+++ b/extension/src/experiment-apis/translateUi/content/translation-notification.js
@@ -166,6 +166,8 @@ window.MozTranslationNotification = class extends MozElements.Notification {
       this.state = aTranslation.uiState.infobarState;
     }
 
+    /*
+    // The welcome popup/notification is currently disabled
     const kWelcomePref = "browser.translation.ui.welcomeMessageShown";
     if (
       Services.prefs.prefHasUserValue(kWelcomePref) ||
@@ -240,6 +242,7 @@ window.MozTranslationNotification = class extends MozElements.Notification {
       },
       { once: true },
     );
+     */
   }
 
   _getAnonElt(aAnonId) {

--- a/extension/web-ext-config.js
+++ b/extension/web-ext-config.js
@@ -47,14 +47,14 @@ if (targetBrowser === "firefox") {
     "about:debugging#/runtime/this-firefox",
   ];
   defaultConfig.run.pref = [
-    "browser.aboutConfig.showWarning=false",
-    "browser.proton.enabled=true",
     "extensions.experiments.enabled=true",
+    "browser.proton.enabled=true",
     "dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled=true",
     "javascript.options.wasm_simd=true",
     "javascript.options.wasm_simd_wormhole=true",
-    // "browser.translation.ui.show=true",
-    // "browser.translation.detectLanguage=true",
+    "browser.translation.ui.show=false",
+    "browser.translation.detectLanguage=false",
+    "browser.aboutConfig.showWarning=false",
     "browser.ctrlTab.recentlyUsedOrder=false",
   ];
   defaultConfig.filename = `${extensionId}-{version}-firefox.xpi`;


### PR DESCRIPTION
Installation docs for non-developers: https://github.com/mozilla-extensions/bergamot-browser-extension/blob/release-0.2.0-prep/extension/docs/INSTALL.md
Documentation for developers: https://github.com/mozilla-extensions/bergamot-browser-extension/blob/release-0.2.0-prep/extension/docs/DEV.md

Please review by testing the installation and/or developer instructions above, and report any issues in this PR, so that we can fix them and update the final release builds with the results of this PR.

Fixes #28