### PR TITLE
Fix telemetry app ids

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,12 @@ const SentryWebpackPlugin = require("@sentry/webpack-plugin");
 const BundleAnalyzerPlugin = require("webpack-bundle-analyzer")
   .BundleAnalyzerPlugin;
 
-const { targetEnvironment, buildPath, ui } = require("./build-config.js");
+const {
+  targetBrowser,
+  targetEnvironment,
+  buildPath,
+  ui,
+} = require("./build-config.js");
 
 const dotEnvPath =
   targetEnvironment === "production"
@@ -79,13 +84,18 @@ if (targetEnvironment === "production") {
 }
 
 // telemetry configuration
-let telemetryAppId;
-if (ui === "firefox-infobar-ui") {
-  telemetryAppId = "org-mozilla-bergamot";
-} else if (ui === "cross-browser-ui") {
-  telemetryAppId = "org-mozilla-bergamot-cross-browser";
-} else {
-  throw Error("Could not determine telemetry app id");
+let telemetryAppId = "org-mozilla-bergamot-test";
+
+if (targetEnvironment === "production") {
+  if (ui === "firefox-infobar-ui") {
+    telemetryAppId = "org-mozilla-bergamot";
+  } else if (ui === "cross-browser-ui" && targetBrowser === "firefox") {
+    telemetryAppId = "org-mozilla-bergamot-cross-browser-firefox";
+  } else if (ui === "cross-browser-ui" && targetBrowser === "chrome") {
+    telemetryAppId = "org-mozilla-bergamot-cross-browser-chrome";
+  } else {
+    throw Error("Could not determine telemetry app id");
+  }
 }
 
 plugins.push(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,12 +7,7 @@ const SentryWebpackPlugin = require("@sentry/webpack-plugin");
 const BundleAnalyzerPlugin = require("webpack-bundle-analyzer")
   .BundleAnalyzerPlugin;
 
-const {
-  targetBrowser,
-  targetEnvironment,
-  buildPath,
-  ui,
-} = require("./build-config.js");
+const { targetEnvironment, buildPath, ui } = require("./build-config.js");
 
 const dotEnvPath =
   targetEnvironment === "production"
@@ -86,18 +81,10 @@ if (targetEnvironment === "production") {
 // telemetry configuration
 let telemetryAppId = "org-mozilla-bergamot-test";
 
-// disabled for cross-browser until we figure out which IDs are more suitable
+// use test one for cross-browser until we figure out which IDs are more suitable
 // and get data collection review approval for these channels of distribution
-if (targetEnvironment === "production") {
-  if (ui === "firefox-infobar-ui") {
-    telemetryAppId = "org-mozilla-bergamot";
-  } else if (ui === "cross-browser-ui" && targetBrowser === "firefox") {
-    // telemetryAppId = "org-mozilla-bergamot-cross-browser-firefox";
-  } else if (ui === "cross-browser-ui" && targetBrowser === "chrome") {
-    // telemetryAppId = "org-mozilla-bergamot-cross-browser-chrome";
-  } else {
-    throw Error("Could not determine telemetry app id");
-  }
+if (targetEnvironment === "production" && ui === "firefox-infobar-ui") {
+  telemetryAppId = "org-mozilla-bergamot";
 }
 
 plugins.push(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,13 +86,15 @@ if (targetEnvironment === "production") {
 // telemetry configuration
 let telemetryAppId = "org-mozilla-bergamot-test";
 
+// disabled for cross-browser until we figure out which IDs are more suitable
+// and get data collection review approval for these channels of distribution
 if (targetEnvironment === "production") {
   if (ui === "firefox-infobar-ui") {
     telemetryAppId = "org-mozilla-bergamot";
   } else if (ui === "cross-browser-ui" && targetBrowser === "firefox") {
-    telemetryAppId = "org-mozilla-bergamot-cross-browser-firefox";
+    // telemetryAppId = "org-mozilla-bergamot-cross-browser-firefox";
   } else if (ui === "cross-browser-ui" && targetBrowser === "chrome") {
-    telemetryAppId = "org-mozilla-bergamot-cross-browser-chrome";
+    // telemetryAppId = "org-mozilla-bergamot-cross-browser-chrome";
   } else {
     throw Error("Could not determine telemetry app id");
   }


### PR DESCRIPTION
Fixed app IDs back. This is how they should look at the moment and how they will be enabled in Glean platform. We can rethink this approach later when there is a way to add browser metadata.