### PR TITLE
Clean up Bergamot REST API integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Used in the client
+USE_BERGAMOT_REST_API=0
 BERGAMOT_REST_API_INBOUND_URL=http://127.0.0.1:8787
 SENTRY_DSN=https://<key>@<organization>.ingest.sentry.io/<project>
 

--- a/generate-manifest.js
+++ b/generate-manifest.js
@@ -46,18 +46,16 @@ async function generateManifest({ dotEnvPath }) {
         match_about_blank: false,
       },
     ],
-    permissions: [
-      "<all_urls>",
-      `${process.env.BERGAMOT_REST_API_INBOUND_URL}/*`,
-      "storage",
-      "alarms",
-    ],
+    permissions: ["<all_urls>", "storage", "alarms"],
     icons: {
       48: "icons/extension-icon.48x48.png",
       96: "icons/extension-icon.96x96.png",
       128: "icons/extension-icon.128x128.png",
     },
   };
+  if (process.env.USE_BERGAMOT_REST_API === "1") {
+    manifest.permissions.push(`${process.env.BERGAMOT_REST_API_INBOUND_URL}/*`);
+  }
   if (ui === "firefox-infobar-ui") {
     manifest.hidden = true;
     manifest.experiment_apis = {

--- a/src/core/ts/background-scripts/background.js/contentScriptBergamotApiClientPortListener.ts
+++ b/src/core/ts/background-scripts/background.js/contentScriptBergamotApiClientPortListener.ts
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {
-  BergamotApiClient,
-  BergamotRestApiTranslateRequestResult,
-} from "./lib/BergamotApiClient";
+import { BergamotWasmApiClient } from "./translation-api-clients/BergamotWasmApiClient";
 import { Runtime } from "webextension-polyfill-ts";
 import Port = Runtime.Port;
-const bergamotApiClient = new BergamotApiClient();
+import { BergamotRestApiTranslateRequestResult } from "./translation-api-clients/BergamotRestApiClient";
+const bergamotApiClient = new BergamotWasmApiClient();
+// TODO: Possibly make it configurable to build/configure the extension to use the REST API - eg for performance testing / research
+// const bergamotApiClient = new BergamotRestApiClient();
 
 export const contentScriptBergamotApiClientPortListener = (port: Port) => {
   if (port.name !== "port-from-content-script-bergamot-api-client") {

--- a/src/core/ts/background-scripts/background.js/contentScriptBergamotApiClientPortListener.ts
+++ b/src/core/ts/background-scripts/background.js/contentScriptBergamotApiClientPortListener.ts
@@ -5,7 +5,7 @@
 import { BergamotWasmApiClient } from "./translation-api-clients/BergamotWasmApiClient";
 import { Runtime } from "webextension-polyfill-ts";
 import Port = Runtime.Port;
-import { BergamotRestApiTranslateRequestResult } from "./translation-api-clients/BergamotRestApiClient";
+import { TranslationResults } from "./lib/BergamotTranslatorAPI";
 const bergamotApiClient = new BergamotWasmApiClient();
 // TODO: Possibly make it configurable to build/configure the extension to use the REST API - eg for performance testing / research
 // const bergamotApiClient = new BergamotRestApiClient();
@@ -22,7 +22,7 @@ export const contentScriptBergamotApiClientPortListener = (port: Port) => {
   }) {
     // console.debug("Message from content-script-bergamot-api-client:", {m});
     const { texts, from, to, requestId } = m;
-    const results: BergamotRestApiTranslateRequestResult = await bergamotApiClient.sendTranslationRequest(
+    const results: TranslationResults = await bergamotApiClient.sendTranslationRequest(
       texts,
       from,
       to,

--- a/src/core/ts/background-scripts/background.js/contentScriptBergamotApiClientPortListener.ts
+++ b/src/core/ts/background-scripts/background.js/contentScriptBergamotApiClientPortListener.ts
@@ -3,12 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { BergamotWasmApiClient } from "./translation-api-clients/BergamotWasmApiClient";
+import { BergamotRestApiClient } from "./translation-api-clients/BergamotRestApiClient";
 import { Runtime } from "webextension-polyfill-ts";
 import Port = Runtime.Port;
 import { TranslationResults } from "./lib/BergamotTranslatorAPI";
-const bergamotApiClient = new BergamotWasmApiClient();
-// TODO: Possibly make it configurable to build/configure the extension to use the REST API - eg for performance testing / research
-// const bergamotApiClient = new BergamotRestApiClient();
+import { config } from "../../config";
+
+// Currently it is possible build variants of the extension that uses the REST API - eg for performance testing / research
+const bergamotApiClient = config.useBergamotRestApi
+  ? new BergamotRestApiClient()
+  : new BergamotWasmApiClient();
 
 export const contentScriptBergamotApiClientPortListener = (port: Port) => {
   if (port.name !== "port-from-content-script-bergamot-api-client") {

--- a/src/core/ts/background-scripts/background.js/lib/BergamotTranslatorAPI.ts
+++ b/src/core/ts/background-scripts/background.js/lib/BergamotTranslatorAPI.ts
@@ -66,6 +66,7 @@ interface TranslateRequestWorkerMessage extends WorkerMessage {
 export interface TranslationResults {
   originalTexts: string[];
   translatedTexts: string[];
+  qeAnnotatedTranslatedTexts?: string[];
 }
 
 /* eslint-disable no-unused-vars, no-shadow */

--- a/src/core/ts/background-scripts/background.js/translation-api-clients/BergamotRestApiClient.ts
+++ b/src/core/ts/background-scripts/background.js/translation-api-clients/BergamotRestApiClient.ts
@@ -4,6 +4,7 @@
 
 import { config } from "../../../config";
 import { TranslationApiClient } from "../../../content-scripts/dom-translation-content-script.js/dom-translators/BaseDomTranslator";
+import { TranslationResults } from "../lib/BergamotTranslatorAPI";
 
 const MS_IN_A_MINUTE = 60 * 1000;
 
@@ -33,20 +34,20 @@ interface BergamotRestApiTranslationRequestPayload {
 /**
  * The API response format can be referred here: https://github.com/browsermt/mts
  */
-export interface BergamotRestApiTranslateRequestResult {
+interface BergamotRestApiTranslateRequestResult {
   text: BergamotRestApiParagraph[];
 }
 
 // Each 'Paragraph' contains a list of 'Sentence translation' list.
 // There should be only 1 such list.
-export interface BergamotRestApiParagraph {
+interface BergamotRestApiParagraph {
   0: BergamotRestApiSentence[];
 }
 
 // 'Sentence translation' list contains 'Sentence translation' objects
 // where each object contains all the information related to translation
 // of each sentence in source language.
-export interface BergamotRestApiSentence {
+interface BergamotRestApiSentence {
   nBest: {
     translation: string;
     sentenceScore?: string;
@@ -77,10 +78,10 @@ export class BergamotRestApiClient implements TranslationApiClient {
   };
 
   public sendTranslationRequest = async (
-    texts: string | string[],
+    texts: string[],
     _from: string,
     _to: string,
-  ): Promise<BergamotRestApiTranslateRequestResult> => {
+  ): Promise<TranslationResults> => {
     const payload: BergamotRestApiTranslationRequestPayload = {
       text: texts,
       options: {
@@ -113,8 +114,87 @@ export class BergamotRestApiClient implements TranslationApiClient {
     if (!dataResponse.ok) {
       throw new Error("Data response failed");
     }
-    const parsedResponse = await dataResponse.json();
+    const parsedResponse: BergamotRestApiTranslateRequestResult = await dataResponse.json();
     // console.log({ parsedResponse });
-    return parsedResponse;
+
+    const originalTexts = texts;
+    const translatedTexts = [];
+    const qeAnnotatedTranslatedTexts = [];
+
+    parsedResponse.text.map((paragraph: BergamotRestApiParagraph) => {
+      const translationObjects = getBestTranslationObjectsOfEachSentenceInBergamotRestApiParagraph(
+        paragraph,
+      );
+
+      // TODO: Currently the rest server doesn't retain the leading/trailing
+      // whitespace information of sentences. It is a bug on rest server side.
+      // Once it is fixed there, we need to stop appending whitespaces.
+      const separator = " ";
+
+      // Join sentence translations
+      const translatedPlainTextString = translationObjects
+        .map(({ translation }) => translation)
+        .join(separator);
+
+      translatedTexts.push(translatedPlainTextString);
+
+      // Generate QE Annotated HTML for each sentence
+      const qeAnnotatedSentenceHTMLs = translationObjects.map(
+        ({ translation, sentenceScore }) =>
+          generateQEAnnotatedHTML(translation, sentenceScore),
+      );
+      const qeAnnotatedTranslatedMarkup = qeAnnotatedSentenceHTMLs.join(
+        separator,
+      );
+      qeAnnotatedTranslatedTexts.push(qeAnnotatedTranslatedMarkup);
+    });
+
+    return {
+      originalTexts,
+      translatedTexts,
+      qeAnnotatedTranslatedTexts,
+    };
   };
+}
+
+/**
+ * This function parses 'Paragraph' entity of the response for the
+ * the best translations and returns them
+ */
+function getBestTranslationObjectsOfEachSentenceInBergamotRestApiParagraph(
+  paragraph: BergamotRestApiParagraph,
+) {
+  const bestTranslations = [];
+  paragraph[0].forEach(sentenceTranslationList => {
+    // Depending on the request, there might be multiple 'best translations'.
+    // We are fetching the best one (present in 'translation' field).
+    const bestTranslation = sentenceTranslationList.nBest[0];
+    bestTranslations.push(bestTranslation);
+  });
+  return bestTranslations;
+}
+
+/**
+ * This function generates the Quality Estimation annotated HTML of a string
+ * based on its score.
+ *
+ * @param   translation    input string
+ * @param   score          score of the input string
+ * @returns string         QE annotated HTML of input string
+ */
+function generateQEAnnotatedHTML(translation, score) {
+  // Color choices and thresholds below are chosen based on intuitiveness.
+  // They will be changed according to the UI design of Translator once it
+  // is fixed.
+  let color: string;
+  if (score >= -0.2) {
+    color = "green";
+  } else if (score >= -0.5 && score < -0.2) {
+    color = "black";
+  } else if (score >= -0.8 && score < -0.5) {
+    color = "mediumvioletred";
+  } else {
+    color = "red";
+  }
+  return `<span data-translation-qe-score="${score}" style="color:${color}"> ${translation}</span>`;
 }

--- a/src/core/ts/background-scripts/background.js/translation-api-clients/BergamotRestApiClient.ts
+++ b/src/core/ts/background-scripts/background.js/translation-api-clients/BergamotRestApiClient.ts
@@ -3,10 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { config } from "../../../config";
-import {
-  BergamotTranslatorAPI,
-  TranslationResults,
-} from "./BergamotTranslatorAPI";
 import { TranslationApiClient } from "../../../content-scripts/dom-translation-content-script.js/dom-translators/BaseDomTranslator";
 
 const MS_IN_A_MINUTE = 60 * 1000;
@@ -57,7 +53,7 @@ export interface BergamotRestApiSentence {
   }[];
 }
 
-export class BergamotApiClient implements TranslationApiClient {
+export class BergamotRestApiClient implements TranslationApiClient {
   /**
    * Timeout after which we consider a ping submission failed.
    */
@@ -82,45 +78,8 @@ export class BergamotApiClient implements TranslationApiClient {
 
   public sendTranslationRequest = async (
     texts: string | string[],
-    from: string,
-    to: string,
-  ): Promise<BergamotRestApiTranslateRequestResult> => {
-    return this.sendTranslationRequestViaWASMAPI(texts, from, to);
-    // TODO: Possibly make it configurable to build/configure the extension to use the REST API - eg for performance testing / research
-    // return this.sendTranslationRequestViaRestAPI(texts, from, to);
-  };
-
-  public sendTranslationRequestViaWASMAPI = async (
-    texts: string | string[],
-    from: string,
-    to: string,
-  ): Promise<BergamotRestApiTranslateRequestResult> => {
-    if (typeof texts === "string") {
-      texts = [texts];
-    }
-    const translatorApiResults: TranslationResults = await BergamotTranslatorAPI.translate(
-      texts,
-      from,
-      to,
-    );
-    const paragraphs: BergamotRestApiParagraph[] = translatorApiResults.translatedTexts.map(
-      text => {
-        const sentenceList: BergamotRestApiSentence[] = [
-          { nBest: [{ translation: text }] },
-        ];
-        return {
-          0: sentenceList,
-        };
-      },
-    );
-    const results: BergamotRestApiTranslateRequestResult = {
-      text: paragraphs,
-    };
-    return results;
-  };
-
-  public sendTranslationRequestViaRestAPI = async (
-    texts: string | string[],
+    _from: string,
+    _to: string,
   ): Promise<BergamotRestApiTranslateRequestResult> => {
     const payload: BergamotRestApiTranslationRequestPayload = {
       text: texts,

--- a/src/core/ts/background-scripts/background.js/translation-api-clients/BergamotWasmApiClient.ts
+++ b/src/core/ts/background-scripts/background.js/translation-api-clients/BergamotWasmApiClient.ts
@@ -7,39 +7,16 @@ import {
   TranslationResults,
 } from "../lib/BergamotTranslatorAPI";
 import { TranslationApiClient } from "../../../content-scripts/dom-translation-content-script.js/dom-translators/BaseDomTranslator";
-import {
-  BergamotRestApiParagraph,
-  BergamotRestApiSentence,
-  BergamotRestApiTranslateRequestResult,
-} from "./BergamotRestApiClient";
 
 export class BergamotWasmApiClient implements TranslationApiClient {
   public sendTranslationRequest = async (
     texts: string | string[],
     from: string,
     to: string,
-  ): Promise<BergamotRestApiTranslateRequestResult> => {
+  ): Promise<TranslationResults> => {
     if (typeof texts === "string") {
       texts = [texts];
     }
-    const translatorApiResults: TranslationResults = await BergamotTranslatorAPI.translate(
-      texts,
-      from,
-      to,
-    );
-    const paragraphs: BergamotRestApiParagraph[] = translatorApiResults.translatedTexts.map(
-      text => {
-        const sentenceList: BergamotRestApiSentence[] = [
-          { nBest: [{ translation: text }] },
-        ];
-        return {
-          0: sentenceList,
-        };
-      },
-    );
-    const results: BergamotRestApiTranslateRequestResult = {
-      text: paragraphs,
-    };
-    return results;
+    return BergamotTranslatorAPI.translate(texts, from, to);
   };
 }

--- a/src/core/ts/background-scripts/background.js/translation-api-clients/BergamotWasmApiClient.ts
+++ b/src/core/ts/background-scripts/background.js/translation-api-clients/BergamotWasmApiClient.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  BergamotTranslatorAPI,
+  TranslationResults,
+} from "../lib/BergamotTranslatorAPI";
+import { TranslationApiClient } from "../../../content-scripts/dom-translation-content-script.js/dom-translators/BaseDomTranslator";
+import {
+  BergamotRestApiParagraph,
+  BergamotRestApiSentence,
+  BergamotRestApiTranslateRequestResult,
+} from "./BergamotRestApiClient";
+
+export class BergamotWasmApiClient implements TranslationApiClient {
+  public sendTranslationRequest = async (
+    texts: string | string[],
+    from: string,
+    to: string,
+  ): Promise<BergamotRestApiTranslateRequestResult> => {
+    if (typeof texts === "string") {
+      texts = [texts];
+    }
+    const translatorApiResults: TranslationResults = await BergamotTranslatorAPI.translate(
+      texts,
+      from,
+      to,
+    );
+    const paragraphs: BergamotRestApiParagraph[] = translatorApiResults.translatedTexts.map(
+      text => {
+        const sentenceList: BergamotRestApiSentence[] = [
+          { nBest: [{ translation: text }] },
+        ];
+        return {
+          0: sentenceList,
+        };
+      },
+    );
+    const results: BergamotRestApiTranslateRequestResult = {
+      text: paragraphs,
+    };
+    return results;
+  };
+}

--- a/src/core/ts/config.ts
+++ b/src/core/ts/config.ts
@@ -1,5 +1,6 @@
 export const config = {
   bergamotRestApiUrl: process.env.BERGAMOT_REST_API_INBOUND_URL,
+  useBergamotRestApi: process.env.USE_BERGAMOT_REST_API === "1",
   sentryDsn: process.env.SENTRY_DSN,
   telemetryAppId: process.env.TELEMETRY_APP_ID,
   telemetryDebugMode: process.env.NODE_ENV !== "production",

--- a/src/core/ts/content-scripts/dom-translation-content-script.js/dom-translators/BaseDomTranslator.ts
+++ b/src/core/ts/content-scripts/dom-translation-content-script.js/dom-translators/BaseDomTranslator.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { TranslationDocument } from "../TranslationDocument";
-import { BergamotRestApiTranslateRequestResult } from "../../../background-scripts/background.js/lib/BergamotApiClient";
+import { BergamotRestApiTranslateRequestResult } from "../../../background-scripts/background.js/translation-api-clients/BergamotRestApiClient";
 import { TranslationItem } from "../TranslationItem";
 import { MinimalDomTranslator } from "./MinimalDomTranslator";
 

--- a/src/core/ts/content-scripts/dom-translation-content-script.js/dom-translators/BaseDomTranslator.ts
+++ b/src/core/ts/content-scripts/dom-translation-content-script.js/dom-translators/BaseDomTranslator.ts
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { TranslationDocument } from "../TranslationDocument";
-import { BergamotRestApiTranslateRequestResult } from "../../../background-scripts/background.js/translation-api-clients/BergamotRestApiClient";
 import { TranslationItem } from "../TranslationItem";
 import { MinimalDomTranslator } from "./MinimalDomTranslator";
+import { TranslationResults } from "../../../background-scripts/background.js/lib/BergamotTranslatorAPI";
 
 export interface TranslationRequestData {
   markupsToTranslate: string[];
@@ -21,7 +21,7 @@ export interface TranslationApiClient {
     texts: string[],
     from: string,
     to: string,
-  ) => Promise<BergamotRestApiTranslateRequestResult>;
+  ) => Promise<TranslationResults>;
 }
 
 type DomTranslatorRequestFactory = (

--- a/src/core/ts/content-scripts/dom-translation-content-script.js/dom-translators/BergamotDomTranslator.ts
+++ b/src/core/ts/content-scripts/dom-translation-content-script.js/dom-translators/BergamotDomTranslator.ts
@@ -95,18 +95,18 @@ function parseChunkResult(
       try {
         const translatedMarkup =
           translationResponseData.translatedMarkups[index];
-        let qeAnnotatedTranslatedMarkup =
-          translationResponseData.qeAnnotatedTranslatedMarkups[index];
-
-        qeAnnotatedTranslatedMarkup = generateMarkupToTranslateForItem(
-          translationRoot,
-          qeAnnotatedTranslatedMarkup,
-        );
-
         translationRoot.parseTranslationResult(translatedMarkup);
-        translationRoot.parseQeAnnotatedTranslationResult(
-          qeAnnotatedTranslatedMarkup,
-        );
+        if (translationResponseData.qeAnnotatedTranslatedMarkups) {
+          let qeAnnotatedTranslatedMarkup =
+            translationResponseData.qeAnnotatedTranslatedMarkups[index];
+          qeAnnotatedTranslatedMarkup = generateMarkupToTranslateForItem(
+            translationRoot,
+            qeAnnotatedTranslatedMarkup,
+          );
+          translationRoot.parseQeAnnotatedTranslationResult(
+            qeAnnotatedTranslatedMarkup,
+          );
+        }
       } catch (e) {
         errorOccurred = true;
         console.error("Translation error: ", e);

--- a/src/core/ts/content-scripts/dom-translation-content-script.js/dom-translators/BergamotDomTranslatorRequest.spec.ts
+++ b/src/core/ts/content-scripts/dom-translation-content-script.js/dom-translators/BergamotDomTranslatorRequest.spec.ts
@@ -10,7 +10,7 @@ import {
   TranslationResponseData,
 } from "./BaseDomTranslator";
 import { BergamotDomTranslatorRequest } from "./BergamotDomTranslatorRequest";
-import { BergamotApiClient } from "../../../background-scripts/background.js/lib/BergamotApiClient";
+import { BergamotWasmApiClient } from "../../../background-scripts/background.js/translation-api-clients/BergamotWasmApiClient";
 import {
   createElementShowingPlainText,
   createHeader,
@@ -64,7 +64,7 @@ describe(testSuiteName, function() {
       to,
     );
 
-    const bergamotApiClient = new BergamotApiClient();
+    const bergamotApiClient = new BergamotWasmApiClient();
     const translationResponseData: TranslationResponseData & {
       translatedPlainTextStrings: string[];
       plainStringsToTranslate: string[];

--- a/src/core/ts/content-scripts/dom-translation-content-script.js/dom-translators/BergamotDomTranslatorRequest.ts
+++ b/src/core/ts/content-scripts/dom-translation-content-script.js/dom-translators/BergamotDomTranslatorRequest.ts
@@ -11,7 +11,7 @@ import {
 import {
   BergamotRestApiParagraph,
   BergamotRestApiTranslateRequestResult,
-} from "../../../background-scripts/background.js/lib/BergamotApiClient";
+} from "../../../background-scripts/background.js/translation-api-clients/BergamotRestApiClient";
 import { detag, DetaggedString, project } from "./detagAndProject";
 
 /**

--- a/src/core/ts/shared-resources/ContentScriptBergamotApiClient.ts
+++ b/src/core/ts/shared-resources/ContentScriptBergamotApiClient.ts
@@ -6,7 +6,7 @@ import { browser, Runtime } from "webextension-polyfill-ts";
 import Port = Runtime.Port;
 import { nanoid } from "nanoid";
 import { captureExceptionWithExtras } from "./ErrorReporting";
-import { BergamotRestApiTranslateRequestResult } from "../background-scripts/background.js/lib/BergamotApiClient";
+import { BergamotRestApiTranslateRequestResult } from "../background-scripts/background.js/translation-api-clients/BergamotRestApiClient";
 
 export class ContentScriptBergamotApiClient {
   private backgroundContextPort: Port;

--- a/src/core/ts/shared-resources/ContentScriptBergamotApiClient.ts
+++ b/src/core/ts/shared-resources/ContentScriptBergamotApiClient.ts
@@ -6,7 +6,7 @@ import { browser, Runtime } from "webextension-polyfill-ts";
 import Port = Runtime.Port;
 import { nanoid } from "nanoid";
 import { captureExceptionWithExtras } from "./ErrorReporting";
-import { BergamotRestApiTranslateRequestResult } from "../background-scripts/background.js/translation-api-clients/BergamotRestApiClient";
+import { TranslationResults } from "../background-scripts/background.js/lib/BergamotTranslatorAPI";
 
 export class ContentScriptBergamotApiClient {
   private backgroundContextPort: Port;
@@ -20,13 +20,13 @@ export class ContentScriptBergamotApiClient {
     texts: string[],
     from: string,
     to: string,
-  ): Promise<BergamotRestApiTranslateRequestResult> {
+  ): Promise<TranslationResults> {
     return new Promise((resolve, reject) => {
       const requestId = nanoid();
       const resultsMessageListener = async (m: {
         translationRequestResults?: {
           requestId: string;
-          results: BergamotRestApiTranslateRequestResult;
+          results: TranslationResults;
         };
       }) => {
         if (m.translationRequestResults) {
@@ -54,10 +54,5 @@ export class ContentScriptBergamotApiClient {
         requestId,
       });
     });
-  }
-  parseNbestTranslationsFromResponse(parsedResponse) {
-    return parsedResponse.text.map(translation =>
-      translation[0] ? translation[0][0].nBest[0].translation : "",
-    );
   }
 }

--- a/src/cross-browser-ui/ts/extension-pages/main-interface.js/lib/Translator.ts
+++ b/src/cross-browser-ui/ts/extension-pages/main-interface.js/lib/Translator.ts
@@ -17,9 +17,6 @@ export class Translator {
       originLanguage,
       targetLanguage,
     );
-    const nbestTranslations = this.bergamotApiClient.parseNbestTranslationsFromResponse(
-      translationResults,
-    );
-    return nbestTranslations[0];
+    return translationResults.translatedTexts[0];
   }
 }


### PR DESCRIPTION
This relates to #48, but doesn't close that issue fully since I have not removed all REST-API-related code, but instead contained it all to the BergamotRestApiClient class and using it requires a specific (undocumented) build configuration. Builds of the extension that uses the REST API may be useful for performance testing / benchmarking and possibly related user research (as has been discussed on plenaries), and once such opportunities have been explored, we should remove all REST-API-related code.
