### PR TITLE
Improve installation and developer docs a bit

### DIFF
--- a/docs/CI.md
+++ b/docs/CI.md
@@ -6,6 +6,7 @@
 - [Continuous Integration](#continuous-integration)
   - [CircleCI](#circleci)
     - [Run Circle CI locally (requires Docker)](#run-circle-ci-locally-requires-docker)
+    - [Installing artifacts created by CircleCI](#installing-artifacts-created-by-circleci)
   - [Taskcluster](#taskcluster)
     - [Test Taskcluster workflows locally](#test-taskcluster-workflows-locally)
 
@@ -14,6 +15,8 @@
 # Continuous Integration
 
 Both [Circle CI](https://circleci.com/) and Taskcluster is used for continuous integration. CircleCI is used as a general purpose CI, while the Taskcluster integration supports [the automated workflows common to all Mozilla extensions](https://github.com/mozilla-extensions/xpi-manifest/blob/master/docs/adding-a-new-xpi.md#adding-a-new-xpi).
+
+Extension artifacts built via the TaskCluster CI are signed using a development certificate, which enables some privileges in non-release versions of Firefox given that the pref `xpinstall.signatures.dev-root` is set to `true`. These artifacts are used in pre-releases.
 
 ## CircleCI
 
@@ -48,6 +51,24 @@ cd ~/checkout
 ```
 
 Then manually launch the commands from `.circleci/config.yml` until the error has been reproduced.
+
+To forward the GUI to you local Mac workstation, start XQuartz and replace the docker run command above with:
+
+```
+xhost + 127.0.0.1
+docker run -v "$PWD:/home/circleci/checkout" -e DISPLAY=host.docker.internal:0 -it circleci/node:latest-browsers /bin/bash
+```
+
+### Installing artifacts created by CircleCI
+
+Artifacts built via CircleCI are unsigned (just like developer-created local builds), and additional config preferences are necessary to get them to work as expected. First enable the preferences outlined in the [general installation instructions](./INSTALL.md), then:
+
+- Make sure that the following preferences are set to `true` in `about:config`:
+  - `extensions.experiments.enabled`
+  - `javascript.options.wasm_simd`
+  - `javascript.options.wasm_simd_wormhole`
+- Make sure that the following preferences are set to `false` in `about:config`:
+  - `xpinstall.signatures.required`
 
 ## Taskcluster
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,13 +8,6 @@
     - [Preparations](#preparations)
     - [Configuring Nightly and installing the extension](#configuring-nightly-and-installing-the-extension)
     - [Demo](#demo)
-<!--
-  - [Chrome - Cross-browser UI](#chrome---cross-browser-ui)
-  - [Firefox - Cross-browser UI](#firefox---cross-browser-ui)
-    - [Preparations](#preparations-1)
-    - [Configuring Nightly and installing the extension](#configuring-nightly-and-installing-the-extension-1)
-    - [Demo](#demo-1)
--->
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -40,6 +40,8 @@ Screen recording: https://youtu.be/WPLCH84J0is
   - `xpinstall.signatures.dev-root` (Create this pref if it doesn't exist. This is required to be able to install pre-release versions of the extension)
   - `browser.proton.enabled` (This enables the preview of the updated Firefox appearance)
   - `dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled` (Temporary requirement until https://github.com/mozilla/bergamot-translator/issues/37 or https://bugzilla.mozilla.org/show_bug.cgi?id=1674383 is resolved)
+- Make sure that the following preferences are set to `false` in `about:config`:
+  - `xpinstall.signatures.required` (This enables the use of ordinary extensions in the same profile)
 - Click [here](https://github.com/mozilla-extensions/bergamot-browser-extension/releases/download/v0.3.0/bergamot-browser-extension-0.3.0-firefox-infobar-ui.dev-root-signed.xpi) to start the download and installation of the extension
 - Wait for the extension to be downloaded
 - Click `Add` in the popup that comes up


### PR DESCRIPTION
- Fixes #82 
- Includes instructions on how to install unsigned builds of the extension (came up here: https://github.com/mozilla-extensions/bergamot-browser-extension/issues/89#issuecomment-816425517)
- Misc tweaks/cleanups