### PR TITLE
More feedback to the user about the progress of the translation

### DIFF
--- a/src/core/ts/background-scripts/background.js/translation-api-clients/BergamotWasmApiClient.ts
+++ b/src/core/ts/background-scripts/background.js/translation-api-clients/BergamotWasmApiClient.ts
@@ -69,6 +69,7 @@ export class BergamotWasmApiClient implements TranslationApiClient {
         );
       },
       (translationFinishedEventData: TranslationFinishedEventData) => {
+        translationRequestProgress.queued = false;
         translationRequestProgress.translationFinished = true;
         translationRequestProgress.translationWallTimeMs =
           translationFinishedEventData.translationWallTimeMs;

--- a/src/core/ts/background-scripts/background.js/translation-api-clients/BergamotWasmApiClient.ts
+++ b/src/core/ts/background-scripts/background.js/translation-api-clients/BergamotWasmApiClient.ts
@@ -29,6 +29,7 @@ export class BergamotWasmApiClient implements TranslationApiClient {
 
     const translationRequestProgress: TranslationRequestProgress = {
       requestId: undefined,
+      initiationTimestamp: Date.now(),
       queued: false,
       modelLoadNecessary: undefined,
       modelLoading: false,

--- a/src/core/ts/content-scripts/dom-translation-content-script.js/dom-translators/BaseDomTranslator.ts
+++ b/src/core/ts/content-scripts/dom-translation-content-script.js/dom-translators/BaseDomTranslator.ts
@@ -29,6 +29,7 @@ export type FrameTranslationProgressCallback = (
 
 export interface TranslationRequestProgress {
   requestId: string;
+  initiationTimestamp: number;
   queued: boolean;
   modelLoadNecessary: boolean;
   modelLoading: boolean;

--- a/src/core/ts/shared-resources/models/BaseTranslationState.ts
+++ b/src/core/ts/shared-resources/models/BaseTranslationState.ts
@@ -45,6 +45,11 @@ export class BaseTranslationState extends Model({
   totalModelLoadWallTimeMs: prop<number>(),
   totalTranslationWallTimeMs: prop<number>(),
   totalTranslationEngineRequestCount: prop<number>(),
+  queuedTranslationEngineRequestCount: prop<number>(),
+  modelLoadNecessary: prop<boolean>(),
+  modelLoading: prop<boolean>(),
+  modelLoaded: prop<boolean>(),
+  translationFinished: prop<boolean>(),
 }) {
   @computed
   get effectiveTranslateFrom() {

--- a/src/core/ts/shared-resources/models/BaseTranslationState.ts
+++ b/src/core/ts/shared-resources/models/BaseTranslationState.ts
@@ -42,6 +42,7 @@ export class BaseTranslationState extends Model({
   wordCount: prop<number>(),
   wordCountVisible: prop<number>(),
   wordCountVisibleInViewport: prop<number>(),
+  translationInitiationTimestamp: prop<number>(),
   totalModelLoadWallTimeMs: prop<number>(),
   totalTranslationWallTimeMs: prop<number>(),
   totalTranslationEngineRequestCount: prop<number>(),

--- a/src/core/ts/shared-resources/models/ExtensionState.ts
+++ b/src/core/ts/shared-resources/models/ExtensionState.ts
@@ -160,6 +160,28 @@ export class ExtensionState extends Model({
         const totalTranslationEngineRequestCount = documentTranslationStates
           .map(dts => dts.totalTranslationEngineRequestCount)
           .reduce((a, b) => a + b, 0);
+        const queuedTranslationEngineRequestCount = documentTranslationStates
+          .map(dts => dts.queuedTranslationEngineRequestCount)
+          .reduce((a, b) => a + b, 0);
+
+        // Merge translation-progress-related booleans as per src/core/ts/shared-resources/state-management/DocumentTranslationStateCommunicator.ts
+        const modelLoadNecessary = !!documentTranslationStates.filter(
+          (dts: DocumentTranslationState) => dts.modelLoadNecessary,
+        ).length;
+        const modelLoading = modelLoadNecessary
+          ? !!documentTranslationStates.find(
+              (dts: DocumentTranslationState) => dts.modelLoading,
+            )
+          : undefined;
+        const modelLoaded = modelLoadNecessary
+          ? !!documentTranslationStates.find(
+              (dts: DocumentTranslationState) => !dts.modelLoaded,
+            )
+          : undefined;
+        const translationFinished =
+          documentTranslationStates.filter(
+            (dts: DocumentTranslationState) => !dts.translationFinished,
+          ).length === 0;
 
         // Special merging of translation status
         const anyTabHasTranslationStatus = (
@@ -210,6 +232,11 @@ export class ExtensionState extends Model({
           totalModelLoadWallTimeMs,
           totalTranslationWallTimeMs,
           totalTranslationEngineRequestCount,
+          queuedTranslationEngineRequestCount,
+          modelLoadNecessary,
+          modelLoading,
+          modelLoaded,
+          translationFinished,
         };
 
         const tabTranslationState = new TabTranslationState(

--- a/src/core/ts/shared-resources/models/ExtensionState.ts
+++ b/src/core/ts/shared-resources/models/ExtensionState.ts
@@ -165,6 +165,12 @@ export class ExtensionState extends Model({
           .reduce((a, b) => a + b, 0);
 
         // Merge translation-progress-related booleans as per src/core/ts/shared-resources/state-management/DocumentTranslationStateCommunicator.ts
+        const translationInitiationTimestamps = documentTranslationStates.map(
+          (dts: DocumentTranslationState) => dts.translationInitiationTimestamp,
+        );
+        const translationInitiationTimestamp = Math.min(
+          ...translationInitiationTimestamps,
+        );
         const modelLoadNecessary = !!documentTranslationStates.filter(
           (dts: DocumentTranslationState) => dts.modelLoadNecessary,
         ).length;
@@ -229,6 +235,7 @@ export class ExtensionState extends Model({
           wordCount,
           wordCountVisible,
           wordCountVisibleInViewport,
+          translationInitiationTimestamp,
           totalModelLoadWallTimeMs,
           totalTranslationWallTimeMs,
           totalTranslationEngineRequestCount,

--- a/src/core/ts/shared-resources/state-management/DocumentTranslationStateCommunicator.ts
+++ b/src/core/ts/shared-resources/state-management/DocumentTranslationStateCommunicator.ts
@@ -73,6 +73,28 @@ export class DocumentTranslationStateCommunicator {
       .reduce((a, b) => a + b, 0);
     const totalTranslationEngineRequestCount =
       translationRequestProgressEntries.length;
+    const queuedTranslationEngineRequestCount = translationRequestProgressEntries.filter(
+      (trp: TranslationRequestProgress) => trp.queued,
+    ).length;
+
+    // Merge translation-progress-related booleans
+    const modelLoadNecessary = !!translationRequestProgressEntries.filter(
+      (trp: TranslationRequestProgress) => trp.modelLoadNecessary,
+    ).length;
+    const modelLoading = modelLoadNecessary
+      ? !!translationRequestProgressEntries.find(
+          (trp: TranslationRequestProgress) => trp.modelLoading,
+        )
+      : undefined;
+    const modelLoaded = modelLoadNecessary
+      ? !!translationRequestProgressEntries.find(
+          (trp: TranslationRequestProgress) => !trp.modelLoaded,
+        )
+      : undefined;
+    const translationFinished =
+      translationRequestProgressEntries.filter(
+        (trp: TranslationRequestProgress) => !trp.translationFinished,
+      ).length === 0;
 
     setTimeout(() => {
       this.extensionState.patchDocumentTranslationStateByFrameInfo(
@@ -92,6 +114,31 @@ export class DocumentTranslationStateCommunicator {
             op: "replace",
             path: ["totalTranslationEngineRequestCount"],
             value: totalTranslationEngineRequestCount,
+          },
+          {
+            op: "replace",
+            path: ["queuedTranslationEngineRequestCount"],
+            value: queuedTranslationEngineRequestCount,
+          },
+          {
+            op: "replace",
+            path: ["modelLoadNecessary"],
+            value: modelLoadNecessary,
+          },
+          {
+            op: "replace",
+            path: ["modelLoading"],
+            value: modelLoading,
+          },
+          {
+            op: "replace",
+            path: ["modelLoaded"],
+            value: modelLoaded,
+          },
+          {
+            op: "replace",
+            path: ["translationFinished"],
+            value: translationFinished,
           },
         ],
       );

--- a/src/core/ts/shared-resources/state-management/DocumentTranslationStateCommunicator.ts
+++ b/src/core/ts/shared-resources/state-management/DocumentTranslationStateCommunicator.ts
@@ -87,9 +87,9 @@ export class DocumentTranslationStateCommunicator {
         )
       : undefined;
     const modelLoaded = modelLoadNecessary
-      ? !!translationRequestProgressEntries.find(
-          (trp: TranslationRequestProgress) => !trp.modelLoaded,
-        )
+      ? !!translationRequestProgressEntries
+          .filter((trp: TranslationRequestProgress) => trp.modelLoadNecessary)
+          .find((trp: TranslationRequestProgress) => trp.modelLoaded)
       : undefined;
     const translationFinished =
       translationRequestProgressEntries.filter(

--- a/src/core/ts/shared-resources/state-management/DocumentTranslationStateCommunicator.ts
+++ b/src/core/ts/shared-resources/state-management/DocumentTranslationStateCommunicator.ts
@@ -65,6 +65,12 @@ export class DocumentTranslationStateCommunicator {
         translationRequestProgress,
     );
 
+    const translationInitiationTimestamps = translationRequestProgressEntries.map(
+      (trp: TranslationRequestProgress) => trp.initiationTimestamp,
+    );
+    const translationInitiationTimestamp = Math.min(
+      ...translationInitiationTimestamps,
+    );
     const totalModelLoadWallTimeMs = translationRequestProgressEntries
       .map((trp: TranslationRequestProgress) => trp.modelLoadWallTimeMs || 0)
       .reduce((a, b) => a + b, 0);
@@ -100,6 +106,11 @@ export class DocumentTranslationStateCommunicator {
       this.extensionState.patchDocumentTranslationStateByFrameInfo(
         this.frameInfo,
         [
+          {
+            op: "replace",
+            path: ["translationInitiationTimestamp"],
+            value: translationInitiationTimestamp,
+          },
           {
             op: "replace",
             path: ["totalModelLoadWallTimeMs"],

--- a/src/firefox-infobar-ui/static/experiment-apis/translateUi/TranslationBrowserChromeUi.js
+++ b/src/firefox-infobar-ui/static/experiment-apis/translateUi/TranslationBrowserChromeUi.js
@@ -7,6 +7,7 @@ const TranslationInfoBarStates = {
   STATE_TRANSLATED: 2,
   STATE_ERROR: 3,
   STATE_UNAVAILABLE: 4,
+  STATE_LOADING: 5,
 };
 
 class TranslationBrowserChromeUi {
@@ -90,6 +91,7 @@ class TranslationBrowserChromeUi {
         TranslationInfoBarStates.STATE_TRANSLATING,
         TranslationInfoBarStates.STATE_TRANSLATED,
         TranslationInfoBarStates.STATE_ERROR,
+        TranslationInfoBarStates.STATE_LOADING,
       ].includes(
         this.translationBrowserChromeUiNotificationManager.uiState.infobarState,
       )

--- a/src/firefox-infobar-ui/static/experiment-apis/translateUi/TranslationBrowserChromeUi.js
+++ b/src/firefox-infobar-ui/static/experiment-apis/translateUi/TranslationBrowserChromeUi.js
@@ -7,7 +7,6 @@ const TranslationInfoBarStates = {
   STATE_TRANSLATED: 2,
   STATE_ERROR: 3,
   STATE_UNAVAILABLE: 4,
-  STATE_LOADING: 5,
 };
 
 class TranslationBrowserChromeUi {
@@ -91,7 +90,6 @@ class TranslationBrowserChromeUi {
         TranslationInfoBarStates.STATE_TRANSLATING,
         TranslationInfoBarStates.STATE_TRANSLATED,
         TranslationInfoBarStates.STATE_ERROR,
-        TranslationInfoBarStates.STATE_LOADING,
       ].includes(
         this.translationBrowserChromeUiNotificationManager.uiState.infobarState,
       )

--- a/src/firefox-infobar-ui/static/experiment-apis/translateUi/TranslationBrowserChromeUi.js
+++ b/src/firefox-infobar-ui/static/experiment-apis/translateUi/TranslationBrowserChromeUi.js
@@ -64,7 +64,7 @@ class TranslationBrowserChromeUi {
     // Set all values before showing a new translation infobar.
     this.translationBrowserChromeUiNotificationManager.uiState = uiState;
     this.setInfobarState(uiState.infobarState);
-
+    this.updateTranslationProgress(uiState);
     if (this.shouldShowInfoBar(this.browser.contentPrincipal)) {
       this.showTranslationInfoBarIfNotAlreadyShown();
     } else {
@@ -80,6 +80,20 @@ class TranslationBrowserChromeUi {
     const notif = this.notificationBox.getNotificationWithValue("translation");
     if (notif) {
       notif.state = val;
+    }
+  }
+
+  /**
+   * Informs the infobar element of the current translation progress
+   */
+  updateTranslationProgress(uiState) {
+    const notif = this.notificationBox.getNotificationWithValue("translation");
+    if (notif) {
+      const { modelLoading, queuedTranslationEngineRequestCount } = uiState;
+      notif.updateTranslationProgress(
+        modelLoading,
+        queuedTranslationEngineRequestCount,
+      );
     }
   }
 

--- a/src/firefox-infobar-ui/static/experiment-apis/translateUi/content/translation-notification.js
+++ b/src/firefox-infobar-ui/static/experiment-apis/translateUi/content/translation-notification.js
@@ -97,11 +97,21 @@ window.MozTranslationNotification = class extends MozElements.Notification {
   }
 
   updateTranslationProgress(modelLoading, queuedTranslationEngineRequestCount) {
+    let progressLabelValue;
+    // TODO: Only show progress if translation has been going on for at least say, 3 seconds
+    if (modelLoading) {
+      progressLabelValue = "(Currently loading language model...)";
+    } else if (queuedTranslationEngineRequestCount > 0) {
+      progressLabelValue = `(Language model loaded. ${queuedTranslationEngineRequestCount} part${
+        queuedTranslationEngineRequestCount > 1 ? "s" : ""
+      } left to translate)`;
+    } else {
+      progressLabelValue = "";
+    }
     this._getAnonElt("progress-label").setAttribute(
       "value",
-      JSON.stringify({ modelLoading, queuedTranslationEngineRequestCount }),
+      progressLabelValue,
     );
-    // TODO: only show if nothing has happened for 2 seconds for instance
   }
 
   set state(val) {

--- a/src/firefox-infobar-ui/static/experiment-apis/translateUi/content/translation-notification.js
+++ b/src/firefox-infobar-ui/static/experiment-apis/translateUi/content/translation-notification.js
@@ -34,7 +34,7 @@ window.MozTranslationNotification = class extends MozElements.Notification {
             <button class="notification-button" label="&translation.notNow.button;" anonid="notNow" oncommand="this.closest('notification').notNow();"/>
           </hbox>
           <vbox class="translating-box" pack="center">
-            <label value="&translation.translatingContent.label;"/>
+            <hbox><label value="&translation.translatingContent.label;"/><label anonid="progress-label" value=""/></hbox>
           </vbox>
           <hbox class="translated-box" align="center">
             <label value="&translation.translatedFrom.label;"/>
@@ -96,6 +96,13 @@ window.MozTranslationNotification = class extends MozElements.Notification {
     }
   }
 
+  translationProgressUpdate() {
+    this._getAnonElt("progress-label").setAttribute(
+      "value",
+      "(TODO: Report translation progress here)",
+    );
+  }
+
   set state(val) {
     const deck = this._getAnonElt("translationStates");
 
@@ -105,20 +112,15 @@ window.MozTranslationNotification = class extends MozElements.Notification {
     }
 
     let stateName;
-    for (const name of [
-      "OFFER",
-      "TRANSLATING",
-      "TRANSLATED",
-      "ERROR",
-      "STATE_UNAVAILABLE",
-      "LOADING",
-    ]) {
-      if (this.translation.TranslationInfoBarStates["STATE_" + name] === val) {
+    for (const name of ["OFFER", "TRANSLATING", "TRANSLATED", "ERROR"]) {
+      if (Translation["STATE_" + name] === val) {
         stateName = name.toLowerCase();
         break;
       }
     }
     this.setAttribute("state", stateName);
+
+    this.translationProgressUpdate();
 
     // Workaround to show the animated icon also in the "loading" state. Extension-external
     // code specifies that only the "translating" state shows an animated icon

--- a/src/firefox-infobar-ui/static/experiment-apis/translateUi/content/translation-notification.js
+++ b/src/firefox-infobar-ui/static/experiment-apis/translateUi/content/translation-notification.js
@@ -56,6 +56,9 @@ window.MozTranslationNotification = class extends MozElements.Notification {
           <vbox class="translation-unavailable" pack="center">
             <label value="&translation.serviceUnavailable.label;"/>
           </vbox>
+          <vbox class="loading" pack="center">
+            <label value="Loading language model..."/>
+          </vbox>
         </deck>
         <spacer flex="1"/>
         <button type="menu" class="notification-button" anonid="options" label="&translation.options.menu;">
@@ -102,13 +105,26 @@ window.MozTranslationNotification = class extends MozElements.Notification {
     }
 
     let stateName;
-    for (const name of ["OFFER", "TRANSLATING", "TRANSLATED", "ERROR"]) {
-      if (Translation["STATE_" + name] === val) {
+    for (const name of [
+      "OFFER",
+      "TRANSLATING",
+      "TRANSLATED",
+      "ERROR",
+      "STATE_UNAVAILABLE",
+      "LOADING",
+    ]) {
+      if (this.translation.TranslationInfoBarStates["STATE_" + name] === val) {
         stateName = name.toLowerCase();
         break;
       }
     }
     this.setAttribute("state", stateName);
+
+    // Workaround to show the animated icon also in the "loading" state. Extension-external
+    // code specifies that only the "translating" state shows an animated icon
+    if (stateName === "loading") {
+      this.setAttribute("state", "translating");
+    }
 
     if (val === this.translation.TranslationInfoBarStates.STATE_TRANSLATED) {
       this._handleButtonHiding();

--- a/src/firefox-infobar-ui/static/experiment-apis/translateUi/content/translation-notification.js
+++ b/src/firefox-infobar-ui/static/experiment-apis/translateUi/content/translation-notification.js
@@ -96,11 +96,12 @@ window.MozTranslationNotification = class extends MozElements.Notification {
     }
   }
 
-  translationProgressUpdate() {
+  updateTranslationProgress(modelLoading, queuedTranslationEngineRequestCount) {
     this._getAnonElt("progress-label").setAttribute(
       "value",
-      "(TODO: Report translation progress here)",
+      JSON.stringify({ modelLoading, queuedTranslationEngineRequestCount }),
     );
+    // TODO: only show if nothing has happened for 2 seconds for instance
   }
 
   set state(val) {
@@ -119,8 +120,6 @@ window.MozTranslationNotification = class extends MozElements.Notification {
       }
     }
     this.setAttribute("state", stateName);
-
-    this.translationProgressUpdate();
 
     // Workaround to show the animated icon also in the "loading" state. Extension-external
     // code specifies that only the "translating" state shows an animated icon

--- a/src/firefox-infobar-ui/static/experiment-apis/translateUi/content/translation-notification.js
+++ b/src/firefox-infobar-ui/static/experiment-apis/translateUi/content/translation-notification.js
@@ -56,9 +56,6 @@ window.MozTranslationNotification = class extends MozElements.Notification {
           <vbox class="translation-unavailable" pack="center">
             <label value="&translation.serviceUnavailable.label;"/>
           </vbox>
-          <vbox class="loading" pack="center">
-            <label value="Loading language model..."/>
-          </vbox>
         </deck>
         <spacer flex="1"/>
         <button type="menu" class="notification-button" anonid="options" label="&translation.options.menu;">
@@ -96,10 +93,15 @@ window.MozTranslationNotification = class extends MozElements.Notification {
     }
   }
 
-  updateTranslationProgress(modelLoading, queuedTranslationEngineRequestCount) {
+  updateTranslationProgress(
+    shouldShowTranslationProgress,
+    modelLoading,
+    queuedTranslationEngineRequestCount,
+  ) {
     let progressLabelValue;
-    // TODO: Only show progress if translation has been going on for at least say, 3 seconds
-    if (modelLoading) {
+    if (!shouldShowTranslationProgress) {
+      progressLabelValue = "";
+    } else if (modelLoading) {
       progressLabelValue = "(Currently loading language model...)";
     } else if (queuedTranslationEngineRequestCount > 0) {
       progressLabelValue = `(Language model loaded. ${queuedTranslationEngineRequestCount} part${

--- a/src/firefox-infobar-ui/ts/background-scripts/background.js/NativeTranslateUiBroker.ts
+++ b/src/firefox-infobar-ui/ts/background-scripts/background.js/NativeTranslateUiBroker.ts
@@ -44,6 +44,7 @@ interface NativeTranslateUiState {
   supportedSourceLanguages: string[];
   supportedTargetLanguages: string[];
   // Translation progress
+  translationDurationMs: number;
   modelLoading: boolean;
   queuedTranslationEngineRequestCount: number;
 }
@@ -141,6 +142,9 @@ export class NativeTranslateUiBroker {
         allPossiblySupportedTargetLanguages,
       } = await summarizeLanguageSupport(detectedLanguage);
 
+      const translationDurationMs =
+        Date.now() - tts.translationInitiationTimestamp;
+
       return {
         acceptedTargetLanguages,
         detectedLanguage,
@@ -154,6 +158,7 @@ export class NativeTranslateUiBroker {
         supportedSourceLanguages,
         supportedTargetLanguages: allPossiblySupportedTargetLanguages,
         // Translation progress
+        translationDurationMs,
         modelLoading: tts.modelLoading,
         queuedTranslationEngineRequestCount:
           tts.queuedTranslationEngineRequestCount,

--- a/src/firefox-infobar-ui/ts/background-scripts/background.js/NativeTranslateUiBroker.ts
+++ b/src/firefox-infobar-ui/ts/background-scripts/background.js/NativeTranslateUiBroker.ts
@@ -43,6 +43,9 @@ interface NativeTranslateUiState {
   // Additionally, since supported source and target languages are only supported in specific pairs, keep these dynamic:
   supportedSourceLanguages: string[];
   supportedTargetLanguages: string[];
+  // Translation progress
+  modelLoading: boolean;
+  queuedTranslationEngineRequestCount: number;
 }
 
 type StandardInfobarInteractionEvent = Event<
@@ -150,6 +153,10 @@ export class NativeTranslateUiBroker {
         // Additionally, since supported source and target languages are only supported in specific pairs, keep these dynamic:
         supportedSourceLanguages,
         supportedTargetLanguages: allPossiblySupportedTargetLanguages,
+        // Translation progress
+        modelLoading: tts.modelLoading,
+        queuedTranslationEngineRequestCount:
+          tts.queuedTranslationEngineRequestCount,
       };
     };
     const nativeTranslateUiStateInfobarStateFromTranslationStatus = (


### PR DESCRIPTION
Adds more feedback to the user about the progress of the translation.
Fixes #33

Note: No bells and whistles. No carefully designed UI change. Just more feedback to the user about the progress of the translation. Meant as a technical proof of concept to feed into UX design workflows (who can decide whether or not any actual translation progress text/messages should be displayed, or if a progress bar should be used, or nothing at all etc).