### PR TITLE
Localize translation progress text using the browser.i18n web extension api

### DIFF
--- a/src/firefox-infobar-ui/static/_locales/en_US/messages.json
+++ b/src/firefox-infobar-ui/static/_locales/en_US/messages.json
@@ -6,5 +6,41 @@
   "extensionDescription": {
     "message": "Neural Machine Translation for the browser.",
     "description": "Description of the extension."
+  },
+  "currentlyDownloadingLanguageModel": {
+    "message": "Currently downloading language model",
+    "description": "Informs the user that the translations feature is currently downloading the language model files."
+  },
+  "detailedDownloadProgress": {
+    "message": "$PERCENTAGE$% out of $MB$ mb downloaded",
+    "description": "Informs the user how the language model file downloading is progressing.",
+    "placeholders": {
+      "percentage": {
+        "content": "$1",
+        "example": "50"
+      },
+      "mb": {
+        "content": "$2",
+        "example": "22.2"
+      }
+    }
+  },
+  "currentlyLoadingLanguageModel": {
+    "message": "Currently loading language model",
+    "description": "Informs the user that the translations feature is currently loading the language model files into memory."
+  },
+  "loadedLanguageModel": {
+    "message": "Language model loaded",
+    "description": "Informs the user that the translations feature is has loaded the language model files into memory."
+  },
+  "partsLeftToTranslate": {
+    "message": "Parts left to translate: $NUM$",
+    "description": "Informs the user that the translations feature has $NUM$ parts left to translate.",
+    "placeholders": {
+      "num": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   }
 }

--- a/src/firefox-infobar-ui/static/_locales/es_ES/messages.json
+++ b/src/firefox-infobar-ui/static/_locales/es_ES/messages.json
@@ -1,0 +1,46 @@
+{
+  "extensionName": {
+    "message": "Traducciones de Firefox",
+    "description": "Name of the extension"
+  },
+  "extensionDescription": {
+    "message": "Traducción de la Máquina Neural para el navegador.",
+    "description": "Description of the extension."
+  },
+  "currentlyDownloadingLanguageModel": {
+    "message": "Actualmente descargando el modelo de idioma",
+    "description": "Informs the user that the translations feature is currently downloading the language model files."
+  },
+  "detailedDownloadProgress": {
+    "message": "$PERCENTAGE$% de $MB$ mb descargado",
+    "description": "Informs the user how the language model file downloading is progressing.",
+    "placeholders": {
+      "percentage": {
+        "content": "$1",
+        "example": "50"
+      },
+      "mb": {
+        "content": "$2",
+        "example": "22.2"
+      }
+    }
+  },
+  "currentlyLoadingLanguageModel": {
+    "message": "Actualmente cargar el modelo de idioma",
+    "description": "Informs the user that the translations feature is currently loading the language model files into memory."
+  },
+  "loadedLanguageModel": {
+    "message": "Modelo de lenguaje cargado",
+    "description": "Informs the user that the translations feature is has loaded the language model files into memory."
+  },
+  "partsLeftToTranslate": {
+    "message": "Partes que quedan para traducir: $NUM$",
+    "description": "Informs the user that the translations feature has $NUM$ parts left to translate.",
+    "placeholders": {
+      "num": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
+  }
+}

--- a/src/firefox-infobar-ui/static/experiment-apis/translateUi/TranslationBrowserChromeUi.js
+++ b/src/firefox-infobar-ui/static/experiment-apis/translateUi/TranslationBrowserChromeUi.js
@@ -109,10 +109,7 @@ class TranslationBrowserChromeUi {
     if (notif) {
       const {
         translationDurationMs,
-        modelLoading,
-        queuedTranslationEngineRequestCount,
-        modelDownloading,
-        modelDownloadProgress,
+        localizedTranslationProgressText,
       } = uiState;
 
       // Always cancel ongoing timers so that we start from a clean state
@@ -133,10 +130,7 @@ class TranslationBrowserChromeUi {
         this.shouldShowTranslationProgressTimer = setTimeout(() => {
           notif.updateTranslationProgress(
             true,
-            modelLoading,
-            queuedTranslationEngineRequestCount,
-            modelDownloading,
-            modelDownloadProgress,
+            localizedTranslationProgressText,
           );
           clearTimeout(this.shouldShowTranslationProgressTimer);
         }, thresholdMsAfterWhichToShouldTranslationProgress - translationDurationMs);
@@ -145,10 +139,7 @@ class TranslationBrowserChromeUi {
       }
       notif.updateTranslationProgress(
         shouldShowTranslationProgress,
-        modelLoading,
-        queuedTranslationEngineRequestCount,
-        modelDownloading,
-        modelDownloadProgress,
+        localizedTranslationProgressText,
       );
     }
   }

--- a/src/firefox-infobar-ui/static/experiment-apis/translateUi/content/translation-notification.js
+++ b/src/firefox-infobar-ui/static/experiment-apis/translateUi/content/translation-notification.js
@@ -93,39 +93,13 @@ window.MozTranslationNotification = class extends MozElements.Notification {
     }
   }
 
-  updateTranslationProgress(
+  async updateTranslationProgress(
     shouldShowTranslationProgress,
-    modelLoading,
-    queuedTranslationEngineRequestCount,
-    modelDownloading,
-    modelDownloadProgress,
+    localizedTranslationProgressText,
   ) {
-    let progressLabelValue;
-    if (!shouldShowTranslationProgress) {
-      progressLabelValue = "";
-    } else if (modelDownloading) {
-      const showDetailedProgress =
-        modelDownloadProgress && modelDownloadProgress.bytesDownloaded > 0;
-      progressLabelValue = `(Currently downloading language model...${
-        showDetailedProgress
-          ? ` ${Math.round(
-              (modelDownloadProgress.bytesDownloaded /
-                modelDownloadProgress.bytesToDownload) *
-                100,
-            )}% out of ${Math.round(
-              (modelDownloadProgress.bytesToDownload / 1024 / 1024) * 10,
-            ) / 10} mb downloaded`
-          : ``
-      })`;
-    } else if (modelLoading) {
-      progressLabelValue = "(Currently loading language model...)";
-    } else if (queuedTranslationEngineRequestCount > 0) {
-      progressLabelValue = `(Language model loaded. ${queuedTranslationEngineRequestCount} part${
-        queuedTranslationEngineRequestCount > 1 ? "s" : ""
-      } left to translate)`;
-    } else {
-      progressLabelValue = "";
-    }
+    const progressLabelValue = shouldShowTranslationProgress
+      ? localizedTranslationProgressText
+      : "";
     this._getAnonElt("progress-label").setAttribute(
       "value",
       progressLabelValue,
@@ -168,6 +142,18 @@ window.MozTranslationNotification = class extends MozElements.Notification {
 
   init(translationBrowserChromeUiNotificationManager) {
     this.translation = translationBrowserChromeUiNotificationManager;
+
+    // Localize some strings in this component using Fluent
+    // Temporary approach pending re-merge into gecko-dev and full migration to Fluent
+    /*
+    const { Localization } =
+      ChromeUtils.import("resource://gre/modules/Localization.jsm", {});
+    console.log({Localization})
+    this.tmpL10n = Localization.getLocalization([
+      "translations.ftl",
+    ]);
+    console.log("this.tmpL10n", this.tmpL10n)
+    */
 
     const sortByLocalizedName = function(list) {
       const names = Services.intl.getLanguageDisplayNames(undefined, list);


### PR DESCRIPTION
Fixes #130 

It was non-trivial to apply the (out of date? not applicable to web extension experiment contexts?) instructions in https://firefox-source-docs.mozilla.org/l10n/fluent/tutorial.html to the local copy of the translation infobar in this extension, so I moved the code that determines the translation progress text away from the translation infobar and used the browser.i18n web extension API instead, sending the already localized text into the infobar for display. This is a temporary solution to get the translation progress texts localized for now, until we either choose not to display any translation progress texts and/or properly re-integrate the changes done in our local copy of the translation infobar into the existing implementation in gecko-dev.
