### PR TITLE
Import bergamot translator version info without loading the wasm module

### DIFF
--- a/import-bergamot-translator.sh
+++ b/import-bergamot-translator.sh
@@ -23,7 +23,11 @@ echo "// Note: The source code in this file is imported from bergamot-translator
 echo "// the import-bergamot-translator.sh script in the root of this repo. " >> $TS_FILE
 echo "// Changes will be overwritten on each import!" >> $TS_FILE
 cat "$ARTIFACTS_DIRECTORY/bergamot-translator-worker.js" | sed 's/wasmBinaryFile = "/wasmBinaryFile = "wasm\//g' >> $TS_FILE
-echo "export { addOnPreMain, Module, BERGAMOT_VERSION_FULL };" >> $TS_FILE
+echo "export { addOnPreMain, Module };" >> $TS_FILE
+
+echo "* Extracting the bergamot-translator version info to a separate file"
+VERSION_FILE=src/core/ts/web-worker-scripts/translation-worker.js/bergamot-translator-version.ts
+cat "$ARTIFACTS_DIRECTORY/bergamot-translator-worker.js" | grep 'BERGAMOT_VERSION_FULL' | sed 's/var BERGAMOT_VERSION_FULL/export const BERGAMOT_VERSION_FULL/g' > $VERSION_FILE
 
 echo "* Autoformatting imported TypeScript module"
 yarn prettier src/core/ts/web-worker-scripts/translation-worker.js/bergamot-translator-worker.ts --write

--- a/src/core/ts/web-worker-scripts/translation-worker.js/bergamot-translator-version.ts
+++ b/src/core/ts/web-worker-scripts/translation-worker.js/bergamot-translator-version.ts
@@ -1,0 +1,1 @@
+export const BERGAMOT_VERSION_FULL = "v0.3.1+8b621de";

--- a/src/core/ts/web-worker-scripts/translation-worker.js/bergamot-translator-worker.ts
+++ b/src/core/ts/web-worker-scripts/translation-worker.js/bergamot-translator-worker.ts
@@ -8711,4 +8711,4 @@ if (!ENVIRONMENT_IS_PTHREAD) {
 } else {
   PThread.initWorker();
 }
-export { addOnPreMain, Module, BERGAMOT_VERSION_FULL };
+export { addOnPreMain, Module };

--- a/src/firefox-infobar-ui/ts/background-scripts/background.js/index.ts
+++ b/src/firefox-infobar-ui/ts/background-scripts/background.js/index.ts
@@ -17,7 +17,7 @@ import { connectRootStoreToDevTools } from "../../../../core/ts/background-scrip
 import { MobxKeystoneBackgroundContextHost } from "../../../../core/ts/background-scripts/background.js/state-management/MobxKeystoneBackgroundContextHost";
 import { NativeTranslateUiBroker } from "./NativeTranslateUiBroker";
 import { contentScriptBergamotApiClientPortListener } from "../../../../core/ts/background-scripts/background.js/contentScriptBergamotApiClientPortListener";
-import { BERGAMOT_VERSION_FULL } from "../../../../core/ts/web-worker-scripts/translation-worker.js/bergamot-translator-worker";
+import { BERGAMOT_VERSION_FULL } from "../../../../core/ts/web-worker-scripts/translation-worker.js/bergamot-translator-version";
 const store = new Store(localStorageWrapper);
 /* eslint-disable no-unused-vars */
 // TODO: update typescript-eslint when support for this kind of declaration is supported


### PR DESCRIPTION
Import bergamot translator version number without loading the wasm module (The current emscripten glue code loads the wasm module on import of the glue code. This can probably be avoided by telling emscripten to modularize the glue code, but we don't do that currently.)