### PR TITLE
Avoid a potential short-lived incorrect document translation state when a new translation is requested

### DIFF
--- a/src/core/ts/content-scripts/dom-translation-content-script.js/DomTranslationManager.ts
+++ b/src/core/ts/content-scripts/dom-translation-content-script.js/DomTranslationManager.ts
@@ -206,9 +206,6 @@ export class DomTranslationManager {
       new TranslationDocument(this.document);
 
     console.info("Translating web page");
-    this.documentTranslationStateCommunicator.broadcastUpdatedTranslationStatus(
-      TranslationStatus.TRANSLATING,
-    );
 
     const domTranslator = new BergamotDomTranslator(
       translationDocument,

--- a/src/core/ts/shared-resources/models/ExtensionState.ts
+++ b/src/core/ts/shared-resources/models/ExtensionState.ts
@@ -342,6 +342,11 @@ export class ExtensionState extends Model({
             path: ["translationRequested"],
             value: true,
           },
+          {
+            op: "replace",
+            path: ["translationStatus"],
+            value: TranslationStatus.TRANSLATING,
+          },
         ]);
       },
     );


### PR DESCRIPTION
Move the assignment of TRANSLATING translation status earlier in the translation life cycle, avoiding a potential short-lived incorrect document translation state when a new translation is requested.

Fixes #167 