### PR TITLE
Update fixtures url in two places where it should be updated

### DIFF
--- a/import-bergamot-models.sh
+++ b/import-bergamot-models.sh
@@ -21,12 +21,12 @@ fi
 cd -
 if [ "$MODELS_UPDATED" == "1" ]; then
   echo "* Importing model files from bergamot-models repo"
-  mkdir -p test/fixtures/models
-  mv test/fixtures/models/dummy tmp
-  rm -rf test/fixtures/models/*
-  cp -rf bergamot-models/prod/* test/fixtures/models
-  ls -l test/fixtures/models/*
-  mv tmp test/fixtures/models/dummy
+  mkdir -p test/locally-hosted-files/models
+  mv test/locally-hosted-files/models/dummy tmp
+  rm -rf test/locally-hosted-files/models/*
+  cp -rf bergamot-models/prod/* test/locally-hosted-files/models
+  ls -l test/locally-hosted-files/models/*
+  mv tmp test/locally-hosted-files/models/dummy
 fi
 
 echo "* Done"

--- a/test/in-browser/ts/test-utils.ts
+++ b/test/in-browser/ts/test-utils.ts
@@ -12,9 +12,12 @@ const prettier = require("prettier/standalone");
 const plugins = [require("prettier/parser-html")];
 
 export const fetchFixtureHtml = async fixture => {
-  const fixtureBaseUrl = "http://0.0.0.0:4000";
+  const fixtureBaseUrl = "http://0.0.0.0:4000/fixtures";
   const url = `${fixtureBaseUrl}/${fixture}`;
   const response = await fetch(url);
+  if (response.status > 400) {
+    throw new Error(`Download of fixture ${fixture} failed`);
+  }
   return response.text();
 };
 


### PR DESCRIPTION
This restores the model import script and in-browser tests that uses fixtures