### PR TITLE
Remove the ability to change from and to languages after translation

### DIFF
--- a/src/firefox-infobar-ui/static/experiment-apis/translateUi/content/translation-notification.js
+++ b/src/firefox-infobar-ui/static/experiment-apis/translateUi/content/translation-notification.js
@@ -37,14 +37,10 @@ window.MozTranslationNotification = class extends MozElements.Notification {
             <hbox><label value="&translation.translatingContent.label;"/><label anonid="progress-label" value=""/></hbox>
           </vbox>
           <hbox class="translated-box" align="center">
-            <label value="&translation.translatedFrom.label;"/>
-            <menulist class="notification-button" anonid="fromLanguage" oncommand="this.closest('notification').fromLanguageChanged();">
-              <menupopup/>
-            </menulist>
-            <label value="&translation.translatedTo.label;"/>
-            <menulist class="notification-button" anonid="toLanguage" oncommand="this.closest('notification').toLanguageChanged();">
-              <menupopup/>
-            </menulist>
+            <label value="&translation.translatedFrom.label;" style="margin-right: 4px;"/>
+            <label anonid="fromLanguage" style="margin-inline:0px;font-weight: bold;"/>
+            <label value="&translation.translatedTo.label;" style="margin-inline:3px;"/>
+            <label anonid="toLanguage" style="margin-inline:0px;font-weight: bold;"/>
             <label value="&translation.translatedToSuffix.label;"/>
             <button anonid="showOriginal" class="notification-button" label="&translation.showOriginal.button;" oncommand="this.closest('notification').showOriginal();"/>
             <button anonid="showTranslation" class="notification-button" label="&translation.showTranslation.button;" oncommand="this.closest('notification').showTranslation();"/>
@@ -137,6 +133,8 @@ window.MozTranslationNotification = class extends MozElements.Notification {
   init(translationBrowserChromeUiNotificationManager) {
     this.translation = translationBrowserChromeUiNotificationManager;
 
+    this.localizedLanguagesByCode = {};
+
     const sortByLocalizedName = function(list) {
       const names = Services.intl.getLanguageDisplayNames(undefined, list);
       return list
@@ -146,20 +144,27 @@ window.MozTranslationNotification = class extends MozElements.Notification {
 
     // Fill the lists of supported source languages.
     const detectedLanguage = this._getAnonElt("detectedLanguage");
-    const fromLanguage = this._getAnonElt("fromLanguage");
     const sourceLanguages = sortByLocalizedName(
       this.translation.uiState.supportedSourceLanguages,
     );
     for (const [code, name] of sourceLanguages) {
       detectedLanguage.appendItem(name, code);
-      fromLanguage.appendItem(name, code);
+      this.localizedLanguagesByCode[code] = name;
     }
     detectedLanguage.value = this.translation.uiState.detectedLanguageResults.language;
 
     // translatedFrom is only set if we have already translated this page.
+    const fromLanguage = this._getAnonElt("fromLanguage");
     if (translationBrowserChromeUiNotificationManager.uiState.translatedFrom) {
-      fromLanguage.value =
-        translationBrowserChromeUiNotificationManager.uiState.translatedFrom;
+      for (const [code, name] of sourceLanguages) {
+        detectedLanguage.appendItem(name, code);
+      }
+      fromLanguage.setAttribute(
+        "value",
+        this.localizedLanguagesByCode[
+          translationBrowserChromeUiNotificationManager.uiState.translatedFrom
+        ],
+      );
     }
 
     // Fill the list of supported target languages.
@@ -168,12 +173,16 @@ window.MozTranslationNotification = class extends MozElements.Notification {
       this.translation.uiState.supportedTargetLanguages,
     );
     for (const [code, name] of targetLanguages) {
-      toLanguage.appendItem(name, code);
+      this.localizedLanguagesByCode[code] = name;
     }
 
     if (translationBrowserChromeUiNotificationManager.uiState.translatedTo) {
-      toLanguage.value =
-        translationBrowserChromeUiNotificationManager.uiState.translatedTo;
+      toLanguage.setAttribute(
+        "value",
+        this.localizedLanguagesByCode[
+          translationBrowserChromeUiNotificationManager.uiState.translatedTo
+        ],
+      );
     }
 
     if (translationBrowserChromeUiNotificationManager.uiState.infobarState) {
@@ -292,8 +301,14 @@ window.MozTranslationNotification = class extends MozElements.Notification {
       this.translation.uiState.infobarState ===
       this.translation.TranslationInfoBarStates.STATE_OFFER
     ) {
-      this._getAnonElt("fromLanguage").value = from;
-      this._getAnonElt("toLanguage").value = to;
+      this._getAnonElt("fromLanguage").setAttribute(
+        "value",
+        this.localizedLanguagesByCode[from],
+      );
+      this._getAnonElt("toLanguage").setAttribute(
+        "value",
+        this.localizedLanguagesByCode[to],
+      );
     }
   }
 
@@ -340,25 +355,7 @@ window.MozTranslationNotification = class extends MozElements.Notification {
   }
 
   _getSourceLang() {
-    let lang;
-    if (
-      this.translation.uiState.infobarState ===
-      this.translation.TranslationInfoBarStates.STATE_OFFER
-    ) {
-      lang = this._getAnonElt("detectedLanguage").value;
-    } else {
-      lang = this._getAnonElt("fromLanguage").value;
-
-      // If we have never attempted to translate the page before the
-      // service became unavailable, "fromLanguage" isn't set.
-      if (
-        !lang &&
-        this.translation.uiState.infobarState ===
-          this.translation.TranslationInfoBarStates.STATE_UNAVAILABLE
-      ) {
-        lang = this.translation.uiState.defaultTargetLanguage;
-      }
-    }
+    const lang = this._getAnonElt("detectedLanguage").value;
     if (!lang) {
       throw new Error("Source language is not defined");
     }
@@ -366,10 +363,7 @@ window.MozTranslationNotification = class extends MozElements.Notification {
   }
 
   _getTargetLang() {
-    return (
-      this._getAnonElt("toLanguage").value ||
-      this.translation.uiState.defaultTargetLanguage
-    );
+    return this.translation.uiState.defaultTargetLanguage;
   }
 
   optionsShowing() {


### PR DESCRIPTION
Fixes #202 

This makes the UI less complicated (apt for a first version for testers) and avoids many resulting issues as explained in #202. 

The new UI post translation now looks like this:
<img width="833" alt="Firefox_Nightly" src="https://user-images.githubusercontent.com/793037/121305229-06713000-c906-11eb-94e8-694b720426d3.png">